### PR TITLE
[HTML] Introduce title row with TOC button

### DIFF
--- a/theme/html/default.css
+++ b/theme/html/default.css
@@ -24,3 +24,15 @@ h2:hover a, h2:active a,
 h3:hover a, h2:active a {
   visibility: visible;
 }
+
+/* make the main content start under the fixed top navbar */
+body { padding-top: 70px; }
+/* when clicking a link, make sure that the link appears
+   below the navbar at the top, not at the same location as
+   the navbar at the top, which makes it hidden. */
+:target:before {
+  content:"";
+  display:block;
+  height:70px; /* fixed header height*/
+  margin:-70px 0 0; /* negative fixed header height */
+  }

--- a/theme/html/pandoc_template.html
+++ b/theme/html/pandoc_template.html
@@ -53,70 +53,80 @@ $for(include-before)$
 $include-before$
 $endfor$
 
-$-- This is the main bootstrap container into which all page content is placed
-$-- Class container-lg makes the container 100% wide if the viewport is a
-$-- smaller screen (less than 992px).
-<div class="container-lg">
+$-- This is the bootstrap container into which the top button row and TOC modal
+$-- is placed.
+<div class="container">
 
-$-- The following row represents a screen-wide header. It contains the title,
-$-- copyright info etc.
-<div class="row">
+$-- Implement the button row at the top of the screen.
+<nav class="navbar fixed-top navbar-light bg-light">
+  <div class="container">
+    <button type="button" class="btn btn-primary" data-bs-toggle="modal"
+    data-bs-target="#tocModal">
+      <span>TOC</span>
+    </button>
+    <a class="navbar-brand" href="#">LlSoftSecBook</a>
+  </div>
+</nav>
+
+$-- Show TOC as a "modal", when clicking the "TOC" button at the top left
+$if(toc)$
+  <div class="modal" id="tocModal" tabindex="-1" aria-labelledby="tocModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="tocModalLabel">Table of Contents</h5>
+          <button type="button"
+            class="btn-close" data-bs-dismiss="modal"
+            aria-label="Close"></button>
+        </div>
+        <div class="modal-body" id="TOC">
+          $table-of-contents$
+        </div>
+      </div>
+    </div>
+  </div>
+$endif$
+</div> $-- end of top navbar div with TOC modal
+
+$-- main content bootstrap container
+<main class="container" id="content">
+
 $if(title)$
 <header id="title-block-header">
-<h1 class="title">$title$</h1>
-$if(subtitle)$
-<p class="subtitle">$subtitle$</p>
-$endif$
-$for(author)$
-<p class="author">$author$</p>
-$endfor$
-$if(date)$
-<p class="date">$date$</p>
-$endif$
-<p>
-<a rel="license" href="http://creativecommons.org/licenses/by/4.0/">
-  <img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a><br />
-  This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.
-</p>
-<p>
-$for(copyright)$
-  $copyright.SPDX-FileCopyrightText$<br />
-$endfor$
-</p>
-<p>Version: $VERSION$</p>
+  <h1 class="title">$title$</h1>
+  $if(subtitle)$
+    <p class="subtitle">$subtitle$</p>
+  $endif$
+  $for(author)$
+    <p class="author">$author$</p>
+  $endfor$
+  $if(date)$
+    <p class="date">$date$</p>
+  $endif$
+  <p>
+    <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">
+    <img alt="Creative Commons License" style="border-width:0"
+      src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a>
+    This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">
+      Creative Commons Attribution 4.0 International License</a>.
+  </p>
+  <p>
+  $for(copyright)$
+    $copyright.SPDX-FileCopyrightText$<br />
+  $endfor$
+  </p>
+  <p>Version: $VERSION$</p>
 </header>
 $endif$
-</div> $-- end of header row
 
-$-- start of the main "body" of the page
-$-- Containing TOC on left hand side and main content right hand side.
-<div class="row">
-$if(toc)$
-$--<div class="col-2 d-none d-md-block order-last sidebar">
-  $-- Bootstrap models the available width as "12 columns" wide
-  $-- Reserve 3 of those columns on the left hand side for the table of contents.
-  $-- The next 7 columns are reserved for the main content.
-  $-- Which leaves (12-3-7=2) columns for margin notes (not yet implemented).
-  $-- Note that with col-*md* we specify that we only want these columns to be
-  $-- next to each other if the viewport available is at least md = Medium = 768px
-  $-- (See any bootstrap guide/tutorial).
-<div class="col-md-3">
-<nav id="$idprefix$TOC">
-$table-of-contents$
-</nav>
-</div>
-$endif$
-
-$-- main content bootstrap "column"
-<main class="col-md-7" id="content">
 $body$
-</main>
-
-</div> $-- end of main bootstrap container.
+</main> $-- end of main bootstrap container.
 
 $for(include-after)$
 $include-after$
 $endfor$
+
+
 <script
   src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"
   integrity="sha384-kenU1KFdBIe4zVF0s0G1M5b4hcpxyD9F7jL+jjXkk+Q2h455rYXK/7HAuoJl+0I4"


### PR DESCRIPTION
For now, one button is introduced: TOC.
When clicked, it opens up a modal with the table of contents.

After experimenting with a number of different options on how to display
the table of contents, it seemed best to me to just always leave it
behind a button and a modal, so that independent of screen size it works
the same.

I hope that labeling the button with "TOC" is intuitive enough for
people to see that they have to click there to find the table of
contents.

We could change this later for really large screens to still show a
table-of-contents in a left-or-right hand column. I'm not sure at the
moment if that will be best even for large-screen sizes at the moment,
as I'd also like to have margin notes to display things such as
footnotes, todos and maybe references/citations.

Let's improve the HTML look-and-feel incrementally. This seems like a
useful step to commit.

---

**Stack**:
- #2
- #1 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kbeyls/llsoftsecbook/1)
<!-- Reviewable:end -->
