### PR TITLE
[HTML] Only show TOC 2 levels deep

### DIFF
--- a/theme/html/default.css
+++ b/theme/html/default.css
@@ -25,6 +25,11 @@ h3:hover a, h2:active a {
   visibility: visible;
 }
 
+/* only show TOC 2 levels deep: */
+#TOC ul ul ul {
+  display: none;
+}
+
 /* make the main content start under the fixed top navbar */
 body { padding-top: 70px; }
 /* when clicking a link, make sure that the link appears


### PR DESCRIPTION
I'm not entirely sure if with the table-of-contents always being in a
modal it makes sense to only show the TOC 2 levels deep.
Only showing 2 levels makes the TOC nicer looking and easier to
navigate. But it does show more details...

Would it be useful to have a toggle in the TOC modal to be able to let
the reader change how many levels of TOC they want to see?

---

**Stack**:
- #2 ⬅
- #1


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kbeyls/llsoftsecbook/2)
<!-- Reviewable:end -->
