### PR TITLE
[HTML] Add a "share" button

### DIFF
--- a/theme/html/pandoc_template.html
+++ b/theme/html/pandoc_template.html
@@ -75,6 +75,20 @@ $-- Implement the button row at the top of the screen.
       data-bs-toggle="tooltip" data-bs-title="Suggest an edit"
       href="$github-edit-link$">
       <i class="bi bi-pen"></i></a>
+    <span class="dropdown" id="share-dropdown">
+      <button
+        class="btn btn-outline-primary btn-sm dropdown-toggle"
+        id="share-button"
+        type="button" id="shareDropdownMenuButton"
+        data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false"
+        >
+        <i class="bi bi-share-fill"></i></button>
+      <div class="dropdown-menu" aria-labelledby="shareDropdownMenuButton">
+        <a id="twitter-share-link" class="dropdown-item" href="#" target="_blank">Twitter</a>
+        <a id="mastodon-share-link" class="dropdown-item" href="#" target="_blank">Mastodon</a>
+        <a id="linkedin-share-link" class="dropdown-item" href="#" target="_blank">LinkedIn</a>
+      </div>
+    </span>
     </div>
     <a class="navbar-brand" href="#">LLSoftSecBook</a>
   </div>
@@ -220,6 +234,40 @@ $body$
     // Make links in the TOC be "secondary links". The result is that
     // they will be coloured grey, so will be less distracting.
     jQuery("#toc-sidebar a").addClass("link-secondary");
+
+    // Make the share button work:
+    // Use the web Share API where it is supported, on mobile devices,
+    // where it hopefully allows the user to pick any suitable app they
+    // have installed to share.
+    let useNativeShare = isTouchScreen && navigator.share;
+    let shared_title = "$pagetitle$";
+    let shared_url = "https://llsoftsec.github.io/llsoftsecbook";
+    if (useNativeShare) {
+      let share_button = jQuery('#share-button');
+      share_button.click(function(){
+        navigator.share({ title: shared_title, url: shared_url});
+      });
+      // Disable drop-down functionality of the share button.
+      jQuery('#share-dropdown').removeClass('dropdown');
+      share_button.removeClass('dropdown-toggle');
+      share_button.removeAttr('data-bs-toggle');
+      // and add tooltip to the button now that it's not a drop-down.
+      share_button.attr("data-bs-placement", "bottom");
+      share_button.attr("data-bs-toggle", "tooltip");
+      share_button.attr("data-bs-title", "Share");
+    };
+    let twitter_params = { text: shared_title, url: shared_url,
+                           hashtags: "llsoftsecbook" };
+    jQuery("#twitter-share-link").attr("href",
+      "https://twitter.com/intent/tweet?" + jQuery.param(twitter_params));
+    jQuery("#linkedin-share-link").attr("href",
+      "https://www.linkedin.com/sharing/share-offsite/?"
+      + jQuery.param({url: shared_url}));
+    jQuery("#mastodon-share-link").attr("href",
+      "https://tootpick.org/#"
+      + jQuery.param({text: shared_title + ' ' + shared_url
+                            + ' #llsoftsecbook'}));
+
 
     // Needed to enable the bootstrap tooltips:
     let isTouchScreen = "ontouchstart" in document.documentElement;


### PR DESCRIPTION
... to be able to easily share a pointer to the HTML version of the book on social media.

This uses https://developer.mozilla.org/en-US/docs/Web/API/Web_Share_API api where available.

This web share api is mostly not implemented on desktop browsers.

On mobile browsers where it is implemented, this (I hope) pops up a native "share" functionality, that lets the user choose between whichever app they have installed to share.

When the web share api is not available, it uses a fall-back technique with a drop-down menu that shows a number of the most popular social media. For now, that drop-down menu shows 3 options: twitter, mastodon and linkedin. We could add more if we think that would be useful.

On Safari on desktop, this web share api is implemented, but does not by default allow to share on the major social networks, so I thought it would be better on all desktops to just use the fall-back technique of using a drop-down menu.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kbeyls/llsoftsecbook/3)
<!-- Reviewable:end -->
